### PR TITLE
Pass all channel-related aesthetics to fortify

### DIFF
--- a/R/fortify.R
+++ b/R/fortify.R
@@ -9,25 +9,12 @@
 #' @noRd 
 .fr2dt <- function(x, mapping = NULL, ...){
   dt <- as.data.table(exprs(x))
-  # sort values by aesthetic mapping
-  if(any(c("size", "colour", "fill") %in% mapping$axis)) {
-    cols <- c(
-      "-1" ="size",     # -1 = descending order
-      "1" = "colour",   # 1 = ascending order
-      "1" = "fill"
-    )
-    cols <- cols[
-      !is.na(
-        match(
-          cols,
-          mapping$axis
-        )
-      )
-    ]
+  # sort values by order aesthetic mapping
+  if("order" %in% mapping$axis) {
+    # variable to use for ordering
     setorderv(
-      dt, 
-      cols = mapping$name[as.integer(names(cols))],
-      order = as.integer(names(cols))
+      dt,
+      cols = mapping[axis == "order", name]
     )
   }
   return(dt)

--- a/R/fortify.R
+++ b/R/fortify.R
@@ -7,8 +7,30 @@
 #' @import data.table
 #' @export
 #' @noRd 
-.fr2dt <- function(x, ...){
-  as.data.table(exprs(x))
+.fr2dt <- function(x, mapping = NULL, ...){
+  dt <- as.data.table(exprs(x))
+  # sort values by aesthetic mapping
+  if(any(c("size", "colour", "fill") %in% mapping$axis)) {
+    cols <- c(
+      "-1" ="size",     # -1 = descending order
+      "1" = "colour",   # 1 = ascending order
+      "1" = "fill"
+    )
+    cols <- cols[
+      !is.na(
+        match(
+          cols,
+          mapping$axis
+        )
+      )
+    ]
+    setorderv(
+      dt, 
+      cols = mapping$name[as.integer(names(cols))],
+      order = as.integer(names(cols))
+    )
+  }
+  return(dt)
 }
 
 #' coerce the flowSet to a data.table
@@ -27,16 +49,16 @@
   # subset by columns if applicable
   dims <- attr(x, "dims")
   if(!is.null(dims))
-    x <- x[, dims[, name]]
+    x <- x[, unique(dims[, name])]
   
   if(!is.null(thisFilter)){
     if(is.function(thisFilter)){
-      thisFilter <- thisFilter(x, dims[, name])
+      thisFilter <- thisFilter(x, unique(dims[, name]))
     }
     x <- Subset(x, thisFilter)
   }
     
-  df.list <- .fsdply(x, .fr2dt, .id = ".rownames")
+  df.list <- .fsdply(x, .fr2dt, mapping = dims, .id = ".rownames")
   
 }
 

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -168,6 +168,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
   #lazy-fortifying the plot data
   #####################
   dims <- attr(x[["data"]], "dims")
+  # drop order aesthetic if present (no scale required)
+  dims <- dims[axis != "order", ]
   aes_names <- dims[, axis]
   chnls <- dims[, name]
   

--- a/R/utility.R
+++ b/R/utility.R
@@ -11,7 +11,6 @@
     index <- seq_along(.data)
     .id <- NULL
   }
-  
 
   res <- .do_loop(index = index, .data = .data, ..., .id = .id)
   res <- rbindlist(res)

--- a/vignettes/Top_features_of_ggcyto.Rmd
+++ b/vignettes/Top_features_of_ggcyto.Rmd
@@ -22,7 +22,7 @@ library(ggcyto)
 dataDir <- system.file("extdata",package="flowWorkspaceData")
 ```
 
-## 1: suppoort `3` types of plot constructor 
+## 1: support `3` types of plot constructor 
 
 * represent different levels of complexity and flexibility
 * meet the needs of various plot applications
@@ -30,7 +30,7 @@ dataDir <- system.file("extdata",package="flowWorkspaceData")
 
 ### low level: `ggplot`
 
-The overloaded `fority` methods empower `ggplot`  to work with all the major Cytometry data structures right away, which allows users to do all kinds of highly customized and versitled plots.
+The overloaded `fority` methods empower `ggplot`  to work with all the major Cytometry data structures right away, which allows users to do all kinds of highly customized and versatile plots.
 
 #### `GatingSet`
 ```{r}


### PR DESCRIPTION
@mikejiang, this PR implements my proposed fixes for #91.

Currently, only the xy parameters are exposed to `ggplot` through the various `fortify` methods - attached as `dims` attribute to the `flowSet`. I have expanded this `dims` attribute to capture all top level channel-related aesthetics so that they can be exposed to `ggplot` along with the x-y channels. With these updates, the following code now works as CD44 is extracted along with CD4 and CD8:
```{r}
ggcyto(
    gs[1],
    aes(CD4, CD8, colour = CD44),
    subset  = "T Cells"
) +
geom_point()
```
![image](https://github.com/RGLab/ggcyto/assets/125331387/cafc27b2-7d0e-4ef3-b0bd-841f3af50039)

You will notice that the points are also sorted based on CD44 intensity for better visualisation. I added support for this by passing the `dims` attribute to `.fr2dt()` to allow sorting of rows in the extracted `exprs` matrix. At the moment, I have only added support for sorting by `size`, `colour` and `fill` aesthetics but this can be easily updated in the future. 

I also made sure that we can still specify `pData()` variables through the `aes` as well as per current behaviour with or without `interaction()`:
```{r}
ggcyto(
    gs[1],
    aes(CD4, CD8, colour = CD44, size = name),
    subset  = "T Cells"
) +
geom_point()
```
![image](https://github.com/RGLab/ggcyto/assets/125331387/8aa5fe96-d798-495c-a2ac-c5d33f044df8)


It is also not currently possible to display the colour scale legend on these plot above as they have been completely turned off here:
https://github.com/RGLab/ggcyto/blob/95559e8ea56bcc8d710628bd457d975f94ab8383/R/ggcyto_flowSet.R#L61

I think that line of code should be removed if possible to allow more control over the legend, it should be perfectly fine to display counts for downsampled data in the legend (this is what CytoExploreR does too). I did have a go at removing this line but a lot of tests fail just because all the hexbin plots gain count legends - I don't see this as an issue and the plots actually look better with the legends included. I have left this line untouched for now until I receive confirmation from you that it is OK to remove it.

I ran all the tests locally for changes included in this PR and all test have passed with the exception of a couple of plots where the ellipses had shifted slightly due to the `lymphGate` gating method.

I have also re-rendered all the vignettes which remained unchanged with this PR.