### PR TITLE
Initialize guides as ggproto for ggplot2 v3.5.0.

### DIFF
--- a/R/ggplot_data_frame.R
+++ b/R/ggplot_data_frame.R
@@ -1,14 +1,24 @@
 # copied from ggplot2 2.2.1 since it was removed from 2.3
-ggplot.data.frame <- function (data, mapping = aes(), ..., environment = parent.frame()) 
+ggplot.data.frame <- function (data, mapping = aes(), ..., environment = parent.frame())
 {
   if (!missing(mapping) && !inherits(mapping, "uneval")) {
-    stop("Mapping should be created with `aes() or `aes_()`.", 
+    stop("Mapping should be created with `aes() or `aes_()`.",
          call. = FALSE)
   }
-  p <- structure(list(data = data, layers = list(), scales = ggplot2:::scales_list(), 
-                      mapping = mapping, theme = list(), coordinates = coord_cartesian(), 
-                      facet = facet_null(), plot_env = environment), class = c("gg", 
-                                                                               "ggplot"))
+  p <- structure(
+    list(
+      data = data,
+      layers = list(),
+      scales = ggplot2:::scales_list(),
+      mapping = mapping,
+      theme = list(),
+      coordinates = coord_cartesian(),
+      facet = facet_null(),
+      plot_env = environment,
+      guides = ggplot2:::guides_list()
+    ),
+    class = c("gg", "ggplot")
+  )
   p$labels <- ggplot2:::make_labels(mapping)
   set_last_plot(p)
   p


### PR DESCRIPTION
@mikejiang, here is the guides fix for ggplot2 v3.5.0. We don't explicitly use guides in `ggcyto` but it is a requirement of the`ggplot2` constructor with now requires guides to be `ggproto` objects - our current default value is NULL.

Basically, we need to initialize the guides in `ggplot.data.frame()` to be empty `ggproto` objects so that downstream `ggplot2` guide setup code can run as expected. 

I made minor formatting changes with addition of `guides = ggplot2:::guides_list()` in `ggplot.data.frame()`.

I am able to successfully plot data again with ggplot2 v3.5.0 following this change.