### PR TITLE
Compatibility with future ggplot2 version

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -1,4 +1,6 @@
-if (exists("class_ggplot", envir = asNamespace("ggplot2"))) {
+ggplot_is_S7 <- exists("class_ggplot", envir = asNamespace("ggplot2"))
+
+if (ggplot_is_S7) {
   # Should equal `S7:::class_dispatch(class_ggplot)`
   ggplot_class <- c("ggplot2::ggplot", "ggplot2::gg", "S7_object")
 } else {
@@ -18,4 +20,24 @@ setClass("ggcyto_GatingSet", contains = "ggcyto_flowSet")
 #' @export
 #' @rdname ggcyto
 setClass("ggcyto_GatingLayout", contains = "list", slots = c(arrange.main = "character"))
+
+if (ggplot_is_S7) {
+  setAs(
+    from = "ggplot2::ggplot",
+    to = "ggcyto_flowSet",
+    function(from) {
+      class(from) <- union(c("ggcyto_flowSet", "ggcyto"), class(from))
+      from
+    }
+  )
+
+  setAs(
+    from = "ggcyto_flowSet",
+    to = "ggcyto_GatingSet",
+    function(from) {
+      class(from) <- union("ggcyto_GatingSet", class(from))
+      from
+    }
+  )
+}
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -1,7 +1,14 @@
-setOldClass(c("gg", "ggplot"))
+if (exists("class_ggplot", envir = asNamespace("ggplot2"))) {
+  # Should equal `S7:::class_dispatch(class_ggplot)`
+  ggplot_class <- c("ggplot2::ggplot", "ggplot2::gg", "S7_object")
+} else {
+  ggplot_class <- c("gg", "ggplot")
+}
+setOldClass(ggplot_class)
+
 #' @export
 #' @rdname ggcyto
-setClass("ggcyto", contains = c("gg", "ggplot"))
+setClass("ggcyto", contains = ggplot_class)
 #' @export
 #' @rdname ggcyto
 setClass("ggcyto_flowSet", contains = "ggcyto")

--- a/R/geom_multi_range.R
+++ b/R/geom_multi_range.R
@@ -58,9 +58,9 @@ GeomMultiRange<- ggproto("GeomMultiRange", Geom,
 
 
   draw_panel = function(self, data, panel_params, coord, lineend = "butt", linejoin = "mitre") {
-    data <- ggplot2:::check_linewidth(data, ggplot2:::snake_class(self))
     
     # determien whether x or y 
+    data$linewidth <- data$linewidth %||% data$size
     if("x"%in% colnames(data)){
       axis.used <- "x"
       axis.missing <- "y"

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -117,7 +117,7 @@ print.ggcyto <- function(x, ...) {
     
     x <- ggplot2:::plot_clone(x) #clone plot to avoid tampering original x due to ther referenceClass x$scales
     x <- as.ggplot(x) 
-    ggplot2:::print.ggplot(x)
+    NextMethod()
 }
 
 #' @rdname print.ggcyto

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -256,8 +256,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
       #add new one if not present 
       new.scale <- ggplot2:::make_scale("continuous", this_aes)
       
-      x <- ggplot2:::`+.gg`(x, new.scale)      
       
+      x <-add_gg(x, new.scale)
     }
     ind <- which(x$scales$find(this_aes))
     #apply lazy limits setting
@@ -429,7 +429,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
         stats_mapping <- defaults(stats_mapping, aes(y = density))
       e2.new$mapping <- defaults(e2.new$mapping, stats_mapping)  
       
-      x <- ggplot2:::`+.gg`(x, e2.new)      
+      x <- add_gg(x, e2.new)
     }
   }
   

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -257,7 +257,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
       new.scale <- ggplot2:::make_scale("continuous", this_aes)
       
       
-      x <-add_gg(x, new.scale)
+      x <- gg_add(x, new.scale)
     }
     ind <- which(x$scales$find(this_aes))
     #apply lazy limits setting
@@ -429,7 +429,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
         stats_mapping <- defaults(stats_mapping, aes(y = density))
       e2.new$mapping <- defaults(e2.new$mapping, stats_mapping)  
       
-      x <- add_gg(x, e2.new)
+      x <- gg_add(x, e2.new)
     }
   }
   

--- a/R/ggcyto_GatingLayout.R
+++ b/R/ggcyto_GatingLayout.R
@@ -49,7 +49,7 @@ ggcyto_arrange <- function(x, ...){
     p$data[, name:= popName]
 
     for(i in seq_along(p$layers)){
-      if(!ggplot2:::is.waive(p$layers[[i]][["data"]])){
+      if(!inherits(p$layers[[i]][["data"]], "waiver")){
 
         p$layers[[i]][["data"]][, name:= popName]
       }

--- a/R/ggcyto_flowSet.R
+++ b/R/ggcyto_flowSet.R
@@ -357,9 +357,9 @@ add_ggcyto <- function(e1, e2, e2name){
     
   }
   
-  ggplot2:::`+.gg`(e1, e2)
   
   
+  add_gg(e1, e2)
 }
 
 # Checking if a layer is geom_gate layer for a filterList

--- a/R/ggcyto_flowSet.R
+++ b/R/ggcyto_flowSet.R
@@ -359,7 +359,7 @@ add_ggcyto <- function(e1, e2, e2name){
   
   
   
-  add_gg(e1, e2)
+  gg_add(e1, e2)
 }
 
 # Checking if a layer is geom_gate layer for a filterList

--- a/R/ggplot_data_frame.R
+++ b/R/ggplot_data_frame.R
@@ -1,25 +1,37 @@
 # copied from ggplot2 2.2.1 since it was removed from 2.3
 ggplot.data.frame <- function (data, mapping = aes(), ..., environment = parent.frame())
 {
+
   if (!missing(mapping) && !inherits(mapping, "uneval")) {
     stop("Mapping should be created with `aes() or `aes_()`.",
          call. = FALSE)
   }
-  p <- structure(
-    list(
+
+  class_ggplot <- get0("class_ggplot", asNamespace("ggplot2"))
+  if (is.function(class_ggplot)) {
+    p <- class_ggplot(
       data = data,
-      layers = list(),
-      scales = ggplot2:::scales_list(),
       mapping = mapping,
-      theme = list(),
-      coordinates = coord_cartesian(),
-      facet = facet_null(),
-      plot_env = environment,
-      guides = ggplot2:::guides_list()
-    ),
-    class = c("gg", "ggplot")
-  )
-  p$labels <- ggplot2:::make_labels(mapping)
+      plot_env = environment
+    )
+    class(p) <- union(union(c("ggplot2::ggplot", "ggplot"), class(p)), "gg")
+  } else {
+    p <- structure(
+      list(
+        data = data,
+        layers = list(),
+        scales = ggplot2:::scales_list(),
+        mapping = mapping,
+        theme = list(),
+        coordinates = coord_cartesian(),
+        facet = facet_null(),
+        plot_env = environment,
+        guides = ggplot2:::guides_list()
+      ),
+      class = c("gg", "ggplot")
+    )
+    p$labels <- ggplot2:::make_labels(mapping)
+  }
   set_last_plot(p)
   p
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -89,3 +89,12 @@
 marginalFilter <- function(fs, dims, ...){
   boundaryFilter(x = dims, ...)
 }
+
+add_gg <- function(e1, e2, ...) {
+  f <- get0("add_gg", asNamespace("ggplot2"))
+  if (is.function(f)) {
+    f(e1, e2, ...)
+  } else {
+    ggplot2:::`.gg`(e1, e2, ...)
+  }
+}

--- a/R/utility.R
+++ b/R/utility.R
@@ -90,11 +90,11 @@ marginalFilter <- function(fs, dims, ...){
   boundaryFilter(x = dims, ...)
 }
 
-add_gg <- function(e1, e2, ...) {
-  f <- get0("add_gg", asNamespace("ggplot2"))
+gg_add <- function(e1, e2, ...) {
+  f <- get0("add_gg",envir = asNamespace("ggplot2"))
   if (is.function(f)) {
     f(e1, e2, ...)
   } else {
-    ggplot2:::`.gg`(e1, e2, ...)
+    ggplot2:::`+.gg`(e1, e2, ...)
   }
 }


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The main issue is that ggplot2 has swapped most S3 classes to S7 and because ggcyto wraps ggplot objects in S4 classes, this became a problem.
My S4 is a little bit rusty, and there is very little guidance available on how to interface S7 and S4, but I think this PR would make ggcyto compatible with both old and new version of ggplot2.
Another problem we saw is that there is use of unexported ggplot2 functions via `:::`. We're not comitted to keeping these stable, so it is fragile to use these, see also https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/.
In addition, R CMD check gave numerous warnings about things outside the scope of this PR, which is just a heads up.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to Bioconductor around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
