### PR TITLE
Fix ggplot2 v4 (S7) compatibility

### DIFF
--- a/R/fortify.R
+++ b/R/fortify.R
@@ -12,9 +12,10 @@
   # sort values by order aesthetic mapping
   if("order" %in% mapping$axis) {
     # variable to use for ordering
+    # Use explicit column reference to avoid conflicts with ggplot2 v4 S7 objects
     setorderv(
       dt,
-      cols = mapping[axis == "order", name]
+      cols = mapping[mapping$axis == "order", name]
     )
   }
   return(dt)

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -113,17 +113,21 @@ ggcyto.default <- function(data = NULL, mapping = aes(), ...) {
 #' @export
 #' @method print ggcyto
 print.ggcyto <- function(x, ...) {
-  
-    
     x <- ggplot2:::plot_clone(x) #clone plot to avoid tampering original x due to ther referenceClass x$scales
-    x <- as.ggplot(x) 
-    NextMethod()
+    x <- as.ggplot(x)
+    # Explicitly call ggplot2's print method instead of NextMethod()
+    # NextMethod() fails with ggplot2 v4's S7 system
+    ggplot2:::print.ggplot(x, ...)
 }
 
 #' @rdname print.ggcyto
 #' @method plot ggcyto
 #' @export
-plot.ggcyto <- print.ggcyto
+plot.ggcyto <- function(x, ...) {
+    x <- ggplot2:::plot_clone(x)
+    x <- as.ggplot(x)
+    ggplot2:::plot.ggplot(x, ...)
+}
 
 #--------These S4 methods exsits for plotting ggcyto object automatically in R console---------------#
 #' @export

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -180,11 +180,11 @@ as.ggplot <- function(x, pre_binning = FALSE){
   chnls <- dims[, name]
   
   instrument_range <- x[["instrument_range"]]
-  dtype <- class(x[["data"]])
   gs <- fs <- NULL
   #data needs to be fortified here if geom_gate was not added
-  if(dtype != "data.table"){
-    if(dtype %in% c("GatingSet", "GatingSetList")){#check if it is currently gs
+  # Use inherits() instead of class() comparison for ggplot2 v4 S7 compatibility
+  if(!inherits(x[["data"]], "data.table")){
+    if(inherits(x[["data"]], c("GatingSet", "GatingSetList"))){#check if it is currently gs
       gs <- x[["data"]]
       fs <- fortify_fs(gs)
       

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -112,21 +112,22 @@ ggcyto.default <- function(data = NULL, mapping = aes(), ...) {
 #' 
 #' @export
 #' @method print ggcyto
+#' @importFrom grid grid.newpage grid.draw
 print.ggcyto <- function(x, ...) {
     x <- ggplot2:::plot_clone(x) #clone plot to avoid tampering original x due to ther referenceClass x$scales
     x <- as.ggplot(x)
-    # Explicitly call ggplot2's print method instead of NextMethod()
-    # NextMethod() fails with ggplot2 v4's S7 system
-    ggplot2:::print.ggplot(x, ...)
+    # Use ggplotGrob + grid.draw instead of print.ggplot
+    # ggplot2 v4's S7 system removed print.ggplot
+    grid::grid.newpage()
+    grid::grid.draw(ggplot2::ggplotGrob(x))
+    invisible(x)
 }
 
 #' @rdname print.ggcyto
 #' @method plot ggcyto
 #' @export
 plot.ggcyto <- function(x, ...) {
-    x <- ggplot2:::plot_clone(x)
-    x <- as.ggplot(x)
-    ggplot2:::plot.ggplot(x, ...)
+    print.ggcyto(x, ...)
 }
 
 #--------These S4 methods exsits for plotting ggcyto object automatically in R console---------------#

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -169,7 +169,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
   #####################
   dims <- attr(x[["data"]], "dims")
   # drop order aesthetic if present (no scale required)
-  dims <- dims[axis != "order", ]
+  # Use explicit column reference to avoid conflicts with ggplot2 v4 S7 objects
+  dims <- dims[dims$axis != "order", ]
   aes_names <- dims[, axis]
   chnls <- dims[, name]
   
@@ -207,10 +208,10 @@ as.ggplot <- function(x, pre_binning = FALSE){
           transformed_range <- data_range
           for(col in c("x","y")){
             if(!is.null(x$scales$get_scales(col)$secondary.axis)){
-              transformed_range[, dims[axis==col, name]] <- x$scales$get_scales(col)$transform(transformed_range[,dims[axis==col, name]]) 
+              transformed_range[, dims[dims$axis==col, name]] <- x$scales$get_scales(col)$transform(transformed_range[,dims[dims$axis==col, name]])
             }
           }
-          dummy_scales <- sapply(c("x", "y"), function(i) scale_x_continuous(limits = as.vector(transformed_range[,dims[axis==i, name]])))
+          dummy_scales <- sapply(c("x", "y"), function(i) scale_x_continuous(limits = as.vector(transformed_range[,dims[dims$axis==i, name]])))
           e2$stat_params[["binwidth"]] <- ggplot2:::hex_binwidth(e2$stat_params[["bins"]], dummy_scales)
           x$layers[[i]] <- e2
         }
@@ -249,7 +250,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
   trans <- list()
   for(this_aes in aes_names)
   {
-    dim <- dims[axis == this_aes, name]
+    dim <- dims[dims$axis == this_aes, name]
     # set limits
     if(!x$scales$has_scale(this_aes))
     {
@@ -315,10 +316,10 @@ as.ggplot <- function(x, pre_binning = FALSE){
         transformed_range <- data_range
         for(col in c("x","y")){
           if(!is.null(x$scales$get_scales(col)$secondary.axis)){
-            transformed_range[, dims[axis==col, name]] <- x$scales$get_scales(col)$transform(transformed_range[,dims[axis==col, name]]) 
+            transformed_range[, dims[dims$axis==col, name]] <- x$scales$get_scales(col)$transform(transformed_range[,dims[dims$axis==col, name]])
           }
         }
-        dummy_scales <- sapply(c("x", "y"), function(i)scale_x_continuous(limits = as.vector(transformed_range[,dims[axis==i, name]])))
+        dummy_scales <- sapply(c("x", "y"), function(i)scale_x_continuous(limits = as.vector(transformed_range[,dims[dims$axis==i, name]])))
         e2$stat_params[["binwidth"]] <- ggplot2:::hex_binwidth(bins, dummy_scales)
         x$layers[[i]] <- e2
       }

--- a/R/ggcyto_GatingSet.R
+++ b/R/ggcyto_GatingSet.R
@@ -202,7 +202,8 @@ setMethod("+", c("ggcyto_GatingSet"), `+.ggcyto_GatingSet`)
     
     isMatched<-lapply(cids,function(cid){
       g<-gh_pop_get_gate(gs[[1]],cid)
-      if(class(g)!="booleanFilter") 
+      # Use inherits() instead of class() for ggplot2 v4 S7 compatibility
+      if(!inherits(g, "booleanFilter")) 
       {
         prj<-parameters(g)
         if(length(prj)==1)#1d gate

--- a/R/ggcyto_flowSet.R
+++ b/R/ggcyto_flowSet.R
@@ -44,11 +44,12 @@ ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4,
     
     # drop pData mapping from dim.tbl
     dims.tbl <- dims.tbl[!is.na(dims.tbl$name), ]
-    chnl <- unique(dims.tbl[axis %in% c("x", "y"), name])
-    
+    # Use explicit column reference to avoid conflicts with ggplot2 v4 S7 objects
+    chnl <- unique(dims.tbl[dims.tbl$axis %in% c("x", "y"), name])
+
     # prepare mapping variables - bypass order aesthetic
     for(axis_name in dims.tbl$axis) {
-      mapping[[axis_name]] <- as.symbol(dims.tbl[axis == axis_name, name])
+      mapping[[axis_name]] <- as.symbol(dims.tbl[dims.tbl$axis == axis_name, name])
     }
     
     # drop order from mapping
@@ -293,8 +294,9 @@ add_ggcyto <- function(e1, e2, e2name){
               this_limits <- list()
               if(e2.new == "instrument")
               {
+                # Use explicit column reference to avoid conflicts with ggplot2 v4 S7 objects
                 for(aes_name in dims[, axis])
-                  this_limits[[aes_name]] <- instrument_range[, dims[axis == aes_name, name]]    
+                  this_limits[[aes_name]] <- instrument_range[, dims[dims$axis == aes_name, name]]
               }else if(e2.new == "data")
               {
                 # store the ggcyto pars for the lazy-eval elements for we may not have the final version of data yet at this stage
@@ -318,10 +320,11 @@ add_ggcyto <- function(e1, e2, e2name){
     return(e1)
   }else if(inherits(e2, "labs_cyto")){
     # instantiated it to a concrete labs object
-    
-    lab_txt <- list()    
+
+    lab_txt <- list()
+    # Use explicit column reference to avoid conflicts with ggplot2 v4 S7 objects
     for(axis_name in dims[, axis]){
-      thisDim  <- dims[axis == axis_name, ]
+      thisDim  <- dims[dims$axis == axis_name, ]
       marker <- thisDim[, desc]
       chnl <- thisDim[, name]
       lab_txt[[axis_name]] <- switch(e2[["labels"]]


### PR DESCRIPTION
 ## Summary

  This PR fixes ggcyto compatibility with ggplot2 v4.0+, which migrated from S3 to S7 for its object-oriented system. These changes address issue #109.

  ### Changes

  1. **Fix data.table column references** (`ggcyto.R`, `ggcyto_flowSet.R`, `fortify.R`)
     - Changed `dims[axis == value, ]` to `dims[dims$axis == value, ]`
     - The unquoted `axis` was being resolved to an S7 object instead of a column name

  2. **Fix print/plot methods** (`ggcyto.R`)
     - Replaced `NextMethod()` with explicit `ggplotGrob()` + `grid.draw()`
     - `NextMethod()` fails with ggplot2 v4's S7 method dispatch
     - `print.ggplot` no longer exists in ggplot2 v4

  3. **Fix class() comparisons** (`ggcyto.R`, `ggcyto_GatingSet.R`)
     - Changed `class(x) != "foo"` to `!inherits(x, "foo")`
     - With S7, `class()` can return multiple classes, causing vector comparisons

  ## Test plan

  - [x] Basic ggcyto workflow: `ggcyto(fs, aes(...)) + geom_hex() + geom_gate()`
  - [x] `as.ggplot()` conversion works
  - [x] `print()` displays plots correctly
  - [x] Tested with flowSet data (GvHD example dataset)
  - [x] Full Quarto document render with multiple plot types

  ## Environment

  - ggplot2 4.0.1
  - R 4.5
  - ggcyto 1.37.1 (devel)