### PR TITLE
Support custom plot order in ggcyto.

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -9,6 +9,7 @@
 #' @param y define the y dimension of the plot. Default is NULL, which means 1d densityplot.
 #' @param bins passed to geom_hex
 #' @param axis_inverse_trans logical flag indicating whether to add \link{axis_x_inverse_trans} and axis_x_inverse_trans layers.
+#' @param pData Optional data.frame to use in place of the flowSet/GatingSet pData during plotting. Must have the same sample names (rownames) as the original pData. Columns can have different classes (e.g., factors with custom levels) to control plotting order. The original pData is not modified.
 #' @param ... other arguments passed to ggplot
 #'
 #' @rdname autoplot
@@ -44,26 +45,26 @@
 #' #autoplot(gh , strip.text = "gate")
 #' @export
 #' @export autoplot
-autoplot.flowSet <- function(object, x, y = NULL, bins = 30, ...){
-
+autoplot.flowSet <- function(object, x, y = NULL, bins = 30, pData = NULL, ...){
+  
   # check the dimensions
   if(missing(x))
     stop("'x' must be supplied to ggplot!")
   if(is.null(y)){
-    p <- ggcyto(object, aes_q(x = as.symbol(x)), ...)  #aes_string doesn't play well with special character (e.g. '-')
+    p <- ggcyto(object, aes_q(x = as.symbol(x)), pData = pData, ...)  #aes_string doesn't play well with special character (e.g. '-')
     p <- p + geom_density(fill = "black")
   }else{
-    p <- ggcyto(object, aes_q(x = as.symbol(x), y = as.symbol(y)), ...)
+    p <- ggcyto(object, aes_q(x = as.symbol(x), y = as.symbol(y)), pData = pData, ...)
     p <- p + geom_hex(bins = bins)
-
+    
   }
-
+  
   # apply boundary filter to remove outliers
-#   if(margin){
-#     g <- boundaryFilter(x = dims, tol = 1e-5)
-#     object <- Subset(object, g)
-#   }
-
+  #   if(margin){
+  #     g <- boundaryFilter(x = dims, tol = 1e-5)
+  #     object <- Subset(object, g)
+  #   }
+  
   p
 }
 
@@ -94,33 +95,33 @@ autoplot.flowFrame <- function(object, x, ...){
     object <- fortify_fs(object)
     autoplot(object, x = x, ...)
   }
-    
+  
 }
 
 density_fr_all <- function(fr, strip.text = c("both", "channel", "marker"), ...){
   
   #plot each individual channel
   Objs <- sapply(colnames(fr), function(chnl){
-      p <- autoplot(fr, chnl, ...)
-      p <- p + labs(title = NULL)
-      myTheme <- theme(axis.title = element_text(color = gray(0.3), size = 8)
-                       , axis.text = element_text(color = gray(0.3), size = 6)
-                       , axis.title.y = element_blank()
-                       , strip.text = element_blank()
-                       , plot.margin = unit(c(0,0,0,0), "cm")
-                       , panel.spacing = unit(0, "cm")
-      )
-      p <- p + myTheme
-      attr(p$data, "strip.text") <- chnl
-      p
-    }, simplify = FALSE)
+    p <- autoplot(fr, chnl, ...)
+    p <- p + labs(title = NULL)
+    myTheme <- theme(axis.title = element_text(color = gray(0.3), size = 8)
+                     , axis.text = element_text(color = gray(0.3), size = 6)
+                     , axis.title.y = element_blank()
+                     , strip.text = element_blank()
+                     , plot.margin = unit(c(0,0,0,0), "cm")
+                     , panel.spacing = unit(0, "cm")
+    )
+    p <- p + myTheme
+    attr(p$data, "strip.text") <- chnl
+    p
+  }, simplify = FALSE)
   
   
   #convert it to a special class to dispatch the dedicated print method
   Objs <- as(Objs, "ggcyto_GatingLayout")
   Objs@arrange.main <- identifier(fr)
-
-
+  
+  
   Objs
   
   
@@ -135,7 +136,7 @@ autoplot.GatingSetList <- function(object, ...){
 #' @param gate the gate to be plotted
 #' @export
 #' @rdname autoplot
-autoplot.GatingSet <- function(object, gate, x = NULL,  y = "SSC-A", bins = 30, axis_inverse_trans = TRUE, ...){
+autoplot.GatingSet <- function(object, gate, x = NULL,  y = "SSC-A", bins = 30, axis_inverse_trans = TRUE, pData = NULL, ...){
   if(missing(gate))
     stop("Must specifiy 'gate'!")
   g <- gh_pop_get_gate(object[[1]], gate[1])
@@ -160,15 +161,15 @@ autoplot.GatingSet <- function(object, gate, x = NULL,  y = "SSC-A", bins = 30, 
     }else
       stop("invalid nDims: ", nDims)
   }
-
+  
   mapping <- aes_q(x = as.symbol(x), y = as.symbol(y))
-
-  p <- ggcyto(object, mapping, ...) + geom_hex(bins = bins) + geom_gate(gate) + geom_stats()
+  
+  p <- ggcyto(object, mapping, pData = pData, ...) + geom_hex(bins = bins) + geom_gate(gate) + geom_stats()
   p <- p + ggcyto_par_set(limits = "instrument")
   if(axis_inverse_trans)
     p <- p + axis_x_inverse_trans() + axis_y_inverse_trans()
   p
-
+  
 }
 
 #' @param bool whether to plot boolean gates
@@ -182,11 +183,11 @@ autoplot.GatingSet <- function(object, gate, x = NULL,  y = "SSC-A", bins = 30, 
 #' @export
 #' @rdname autoplot
 autoplot.GatingHierarchy <- function(object, gate, y = "SSC-A", bool=FALSE
-                         , arrange.main = sampleNames(object), arrange=TRUE, merge=TRUE
-                         , projections = list()
-                         , strip.text = c("parent", "gate")
-                         , path = "auto"
-                         , ...){
+                                     , arrange.main = sampleNames(object), arrange=TRUE, merge=TRUE
+                                     , projections = list()
+                                     , strip.text = c("parent", "gate")
+                                     , path = "auto"
+                                     , ...){
   strip.text <- match.arg(strip.text)
   if(missing(gate)){
     gate <- gs_get_pop_paths(object, path = path)
@@ -194,35 +195,35 @@ autoplot.GatingHierarchy <- function(object, gate, y = "SSC-A", bool=FALSE
   }else if (is.numeric(gate)){
     gate <- gs_get_pop_paths(object, path = path)[gate]
   }
-
+  
   #match given axis to channel names
   fr <- gh_pop_get_data(object, use.exprs = FALSE)
   projections <- lapply(projections, function(thisPrj){
     sapply(thisPrj, function(thisAxis)getChannelMarker(fr, thisAxis)[["name"]])
   })
-
-
+  
+  
   plotList <- flowWorkspace:::.mergeGates(object, gate, bool, merge, projections = projections)
   Objs <- lapply(plotList,function(plotObjs){
-
+    
     if(is.list(plotObjs)){
       gate <- plotObjs[["popIds"]]
       parent <- plotObjs[["parentId"]]
       myPrj <- projections[[as.character(gate[1])]]
-
+      
     }else{
       gate <- plotObjs
       parent <- gs_pop_get_parent(object, gate, path = path)
       myPrj <- projections[[as.character(gate)]]
     }
-
-
+    
+    
     if(is.null(myPrj)){
       p <- autoplot.GatingSet(object, gate, y = y, ...)
     }else{
       p <- autoplot.GatingSet(object, gate, x = myPrj[["x"]], y = myPrj[["y"]], ...)
     }
-
+    
     p <- p + labs(title = NULL)
     myTheme <- theme(axis.title = element_text(color = gray(0.3), size = 8)
                      , axis.text = element_text(color = gray(0.3), size = 6)
@@ -232,26 +233,26 @@ autoplot.GatingHierarchy <- function(object, gate, y = "SSC-A", bool=FALSE
                      , legend.position = 'none'
     )
     p <- p + myTheme
-
+    
     #rename sample name with parent or current pop name in order to display it in strip
-
+    
     if(strip.text == "parent"){
       popName <- parent
     }else{
       popName <- paste(gate, collapse = "|")
     }
     attr(p$data, "strip.text") <- popName
-
+    
     p
-
+    
   })
-
+  
   if(arrange){
     #convert it to a special class to dispatch the dedicated print method
     Objs <- as(Objs, "ggcyto_GatingLayout")
     Objs@arrange.main <- arrange.main
   }
-
+  
   Objs
-
+  
 }

--- a/R/compute_stats.R
+++ b/R/compute_stats.R
@@ -9,6 +9,7 @@
 #' @param gates a list of filters
 #' @param type a vector of strings to specify the stats types. can be any or multiple values of "percent", "count", "gate_name", or "MFI" (MFI is currently not supported yet). 
 #' @param value the pre-calculated stats value. when supplied, the stats computing is skipped.
+#' @param pData Optional custom pData to use instead of pData(fs) to control the plot order.
 #' @param ... other arguments passed to stat_position function
 #' @return
 #' a data.table that contains percent and centroid locations as well as pData
@@ -21,7 +22,7 @@
 #' rect.gates <- sapply(sampleNames(fs), function(sn)rect.g)
 #' compute_stats(fs, rect.gates)
 #' compute_stats(fs, rect.gates, type = c("gate_name", "percent"))
-compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, ...){
+compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, pData = NULL, ...){
   
   if(is.null(fs)&&(is.null(value)))
     stop("fs must be provided when 'value' is not supplied!")
@@ -46,12 +47,17 @@ compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, ...)
   stats <- Reduce(function(x,y){
     val <- paste(x[, value], y[, value], sep = "\n")
     x[, value := val]
-    }, x = stats.list)
+  }, x = stats.list)
   
   centroids <- stat_position(gates, ...)
   
   stats <- merge(centroids, stats, by = ".rownames") # merge stats with centroid
-  merge(stats, .pd2dt(pData(fs)), by = ".rownames") # merge with pdata
+  
+  # Get pData and use data.table join to preserve factor levels
+  pd <- .pd2dt(pData(fs), pData = pData)
+  setkeyv(pd, ".rownames")
+  setkeyv(stats, ".rownames")
+  pd[stats, on = ".rownames"]
 }
 
 .stat_gate_name <- function(fs, gates, value = NULL, ...){
@@ -76,14 +82,14 @@ compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, ...)
       if(negated)
         p = 1 - p
       p
-      }, simplify = FALSE)
+    }, simplify = FALSE)
   }
   sn <- names(value)
   value <- unlist(value)
   #format the calculated stats values
   value <- paste(format(value *100,digits=digits),"%",sep="")
   stats <- data.table(value = value, .rownames = sn) 
-    
+  
   stats
 }
 
@@ -99,12 +105,12 @@ compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, ...)
       if(negated)
         ind <- !ind
       sum(ind)
-      }, simplify = FALSE)
+    }, simplify = FALSE)
   }
   sn <- names(value)
   value <- unlist(value)
   stats <- data.table(value = value, .rownames = sn) 
-    
+  
   stats
 }
 
@@ -115,5 +121,5 @@ compute_stats <- function(fs = NULL, gates, type = "percent", value = NULL, ...)
 .stat_MFI <- function(fs, gates, digits = 3, negated = FALSE, ...){
   stop("MFI not supported yet!")
   fs_sub <- Subset(fs, gates)
-     
+  
 }

--- a/R/fortify.R
+++ b/R/fortify.R
@@ -44,7 +44,7 @@
     }
     x <- Subset(x, thisFilter)
   }
-    
+  
   df.list <- .fsdply(x, .fr2dt, mapping = dims, .id = ".rownames")
   
 }
@@ -67,9 +67,15 @@ fortify.flowFrame <- function(model, data, ...){
 
 #' convert pData to data.table
 #' @noRd 
-.pd2dt <- function(pd){
+.pd2dt <- function(pd, pData = NULL){
+  # Use custom pData if provided, otherwise use the original pd
+  if (!is.null(pData)) {
+    pd <- pData
+  }
+  
   pd <- as.data.table(pd, keep.rownames = TRUE)
   setnames(pd, "rn", ".rownames")
+  
   pd
 }
 #' Convert a flowFrame/flowSet/GatingSet to a ggplot-compatible data.table
@@ -80,6 +86,7 @@ fortify.flowFrame <- function(model, data, ...){
 #' @param data not used.
 #' @param ... not used.
 #' 
+#' @param pData Optional custom pData to use instead of pData(model)
 #' @export
 #' @aliases fortify
 #' @return data.table
@@ -95,15 +102,18 @@ fortify.flowFrame <- function(model, data, ...){
 #' 
 #' fr <- fs[[1]]
 #' fortify(fr)#fr is a flowFrame
-fortify.flowSet <- function(model, data, ...){
+fortify.flowSet <- function(model, data, pData = NULL, ...){
   #convert to data.table
-  df <- .fs2dt(model)
-
-  #merge with pData
-  pd <- .pd2dt(pData(model))
+  df <- .fs2dt(model, ...)
   
-  merge(pd, df, by = ".rownames")
-
+  #get pData
+  pd <- .pd2dt(pData(model), pData = pData)
+  
+  # Use data.table join to preserve factor levels from pd
+  setkeyv(pd, ".rownames")
+  setkeyv(df, ".rownames")
+  pd[df, on = ".rownames"]
+  
 }
 
 #' @export
@@ -124,12 +134,11 @@ fortify.GatingSetList <- function(model, ...){
 }
 
 #' @export
-#' @return data.table
 #' @rdname fortify.flowSet
-fortify.GatingSet <- function(model, ...){
+fortify.GatingSet <- function(model, pData = NULL, ...){
   
   fs <- fortify_fs(model, ...)
-  fortify(fs)
+  fortify(fs, pData = pData)
 }
 
 #' Convert a polygonGate to a data.table useful for ggplot
@@ -207,10 +216,11 @@ fortify.ellipsoidGate <- function(model, data = NULL, ...){
 #' Convert a filterList to a data.table useful for ggplot
 #' 
 #' It tries to merge with pData that is associated with filterList as attribute 'pd'
-  
+
 #' @param model filterList
 #' @param data not used
 #' @param nPoints not used
+#' @param pData Optional custom pData to use
 #' @param ... not used.
 #' 
 #' @importFrom plyr name_rows
@@ -222,25 +232,30 @@ fortify.ellipsoidGate <- function(model, data = NULL, ...){
 #' gates <- gs_pop_get_gate(gs, "CD4")
 #' gates <- as(gates, "filterList") #must convert list to filterList in order for the method to dispatch properly
 #' fortify(gates)
-fortify.filterList <- function(model, data = NULL, nPoints = NULL, ...){
-      # convert each filter to df
-      df <- .ldply(model, fortify
-                      # , data = data
-                      # , nPoints = nPoints
-                   , .id = ".rownames")
+fortify.filterList <- function(model, data = NULL, nPoints = NULL, pData = NULL, ...){
+  # convert each filter to df
+  df <- .ldply(model, fortify
+               # , data = data
+               # , nPoints = nPoints
+               , .id = ".rownames")
+  
+  pd <- attr(model,"pd")
+  if(!is.null(pd)){
+    # get pd
     
-      pd <- attr(model,"pd")
-      if(!is.null(pd)){
-          # merge with pd
-            
-        if(!is(pd, "data.table"))
-            pd <- .pd2dt(pd)
-        df <- merge(df, pd, by = ".rownames")  
-        attr(df, "annotated") <- TRUE
-      }
-      # attr(df, "nPoints") <- nPoints
-      
-    df
+    if(!is(pd, "data.table"))
+      pd <- .pd2dt(pd, pData = pData)
+    
+    # Use data.table join to preserve factor levels from pd
+    setkeyv(pd, ".rownames")
+    setkeyv(df, ".rownames")
+    df <- pd[df, on = ".rownames"]
+    
+    attr(df, "annotated") <- TRUE
+  }
+  # attr(df, "nPoints") <- nPoints
+  
+  df
 }
 
 #' Convert a rectangleGate to a data.table useful for ggplot
@@ -279,6 +294,6 @@ fortify.rectangleGate <- function(model, data = NULL, ...){
     df
   }else
     stop("rectangelGate with dimension ", nDim, "is not supported!")
-
+  
 }
 

--- a/R/ggcyto.R
+++ b/R/ggcyto.R
@@ -23,6 +23,7 @@
 #' @param subset character that specifies the node path or node name in the case of GatingSet. 
 #'               Default is "_parent_", which will be substituted with the actual node name 
 #'               based on the geom_gate layer to be added later.
+#' @param pData Optional data.frame to use in place of the flowSet/GatingSet pData during plotting. Must have the same sample names (rownames) as the original pData. Columns can have different classes (e.g., factors with custom levels) to control plotting order in faceted plots. The original pData is not modified.
 #' @param ... other arguments passed to specific methods
 #' @return ggcyto object 
 #' @examples
@@ -114,10 +115,10 @@ ggcyto.default <- function(data = NULL, mapping = aes(), ...) {
 #' @method print ggcyto
 print.ggcyto <- function(x, ...) {
   
-    
-    x <- ggplot2:::plot_clone(x) #clone plot to avoid tampering original x due to ther referenceClass x$scales
-    x <- as.ggplot(x) 
-    NextMethod()
+  
+  x <- ggplot2:::plot_clone(x) #clone plot to avoid tampering original x due to ther referenceClass x$scales
+  x <- as.ggplot(x) 
+  NextMethod()
 }
 
 #' @rdname print.ggcyto
@@ -163,7 +164,7 @@ setMethod("show", "ggcyto", show.ggcyto)
 #' @importFrom hexbin hexbin hcell2xy
 #' @export
 as.ggplot <- function(x, pre_binning = FALSE){
-
+  
   #####################
   #lazy-fortifying the plot data
   #####################
@@ -184,7 +185,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
       
     }else
       fs <- x[["data"]]
-    x[["data"]] <- fortify(fs)
+    # Get pData from plot object
+    x[["data"]] <- fortify(fs, pData = x[["pData"]])
     data_range <- apply(x[["data"]][, chnls, with = FALSE], 2, range)
     rownames(data_range) <- c("min", "max")  
   }else
@@ -220,15 +222,15 @@ as.ggplot <- function(x, pre_binning = FALSE){
           pd <- pData(fs)
           df <- x[["data"]]
           cols <- c(".rownames", colnames(pd))
-  
+          
           df <- df[, {
-  
+            
             binned <- hexbin::hexbin(.SD, xbins = e2$stat_params[["bins"]])
             sd <- hexbin::hcell2xy(binned)
             names(sd) <- colnames(.SD)
             data.table(data.frame(sd,hex_cell_id = binned@cell, count=binned@count, check.names = FALSE))
           }, by = cols]
-  
+          
           x[["data"]] <- df
           e2 <- geom_hex(stat="identity",aes(fill=count))
           x$layers[[i]] <- e2
@@ -269,7 +271,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
       
     }else if(!is.null(par_limits))
       stop("How did you end up here?")
-        
+    
     stats_limits[[dim]] <- x$coordinates[["limits"]][[this_aes]]
     #update breaks and labels
     thisBreaks <- breaks[[this_aes]]
@@ -333,8 +335,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
     #parse the gate from the each gate layer if it is not present in the current geom_stats layer
     if(is.null(gate))
     {
-      
-      pd <- .pd2dt(pData(fs))
+      # Get pData from plot object
+      pd <- .pd2dt(pData(fs), pData = x[["pData"]])
       gates_parsed <- lapply(x$layers, function(layer){
         
         if(is.geom_gate_filterList(layer))#restore filter from fortified data.frame
@@ -357,7 +359,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
     value <- e2[["value"]]
     stat_type <- e2[["type"]]
     
-
+    
     #add default density range
     #In order to ensure the stats visiblity
     #try to put it closer to zero because we don't know the actual density range
@@ -390,7 +392,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
           #bypass stats_postion computing to use data_range as gate_range(as a hack for now)
           location <- "data"
       }
-        
+      
+      # Get pData from plot object
       stats <- compute_stats(fs, gate
                              , type = stat_type
                              , value = value
@@ -399,7 +402,8 @@ as.ggplot <- function(x, pre_binning = FALSE){
                              , negated = negated
                              , adjust = adjust
                              , digits = digits
-                             , location = location)
+                             , location = location
+                             , pData = x[["pData"]])
       
       #restore the stats dimensions to raw scale
       if(length(trans)>0)
@@ -412,7 +416,7 @@ as.ggplot <- function(x, pre_binning = FALSE){
         }  
       }
       
-        
+      
       # instantiate the new stats layer
       thisCall <- quote(geom_label(data = stats))
       # copy all the other parameters

--- a/R/ggcyto_flowSet.R
+++ b/R/ggcyto_flowSet.R
@@ -3,11 +3,33 @@ ggcyto.cytoset <- function(data, ...){
   getS3method("ggcyto", "flowSet")(data, ...)
 }
 #' @rdname ggcyto
+#' @param pData Optional data.frame to use in place of the flowSet/GatingSet pData during plotting. Must have the same sample names (rownames) as the original pData. Columns can have different classes (e.g., factors with custom levels) to control plotting order. The original pData is not modified.
 #' @export
-ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4, ...){
+ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4, pData = NULL, ...){
   #add empty layers recording
   
   fs <- data
+  
+  # If pData is supplied, validate and store in plot object
+  # Don't replace pData(fs) directly as it converts factors to characters
+  if (!is.null(pData)) {
+    pd <- pData(fs)
+    
+    # Validate that rownames match
+    if (!identical(sort(rownames(pData)), sort(rownames(pd)))) {
+      stop("Supplied pData rownames must match the sample names in the flowSet")
+    }
+    
+    # Validate that columns exist (allow additional columns in supplied pData)
+    missing_cols <- setdiff(colnames(pd), colnames(pData))
+    if (length(missing_cols) > 0) {
+      warning("Some columns from original pData are missing in supplied pData: ",
+              paste(missing_cols, collapse = ", "))
+    }
+    
+    # Reorder supplied pData to match sample order in flowSet
+    pData <- pData[rownames(pd), , drop = FALSE]
+  }
   
   #instead of using ggplot.default method to construct the ggplot object
   # we call the underlining s3 method directly to avoid fortifying data at this stage
@@ -23,7 +45,7 @@ ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4,
     
     # dims may reference channels, markers or pData variables
     dims <- sapply(mapping, quo_name)
-
+    
     # update aes mapped parameters with actual channel name
     frm <- getFlowFrame(fs)
     dims.tbl <- .ldply(
@@ -67,7 +89,7 @@ ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4,
     
   }else
     stop("mapping must be supplied to ggplot!")
-    
+  
   #init axis inversed labels and breaks
   p[["axis_inverse_trans"]] <- list()
   # prepend the ggcyto class attribute
@@ -77,6 +99,9 @@ ggcyto.flowSet <- function(data, mapping, filter = NULL, max_nrow_to_plot = 5e4,
   p[["ggcyto_pars"]] <- list()
   
   p[["GeomStats"]] <- list()
+  
+  # Store pData in the plot object
+  p[["pData"]] <- pData
   
   p <- p + ggcyto_par_default()
   # the counts at legend could be reflecting the subsampled data and we want to hide this from user to avoid confusion
@@ -154,13 +179,13 @@ is.ggcyto_flowSet <- function(x){
 #' p + theme(strip.text = element_text(size = 14))
 #' @export
 `+.ggcyto_flowSet` <- function(e1, e2){
-    # Get the name of what was passed in as e2, and pass along so that it
-    # can be displayed in error messages
-    e2name <- deparse(substitute(e2))
-      
-    if      (is.ggcyto_par(e1))  add_par(e1, e2, e2name)
-    else if (is.ggcyto_flowSet(e1)) add_ggcyto(e1, e2, e2name)
-    
+  # Get the name of what was passed in as e2, and pass along so that it
+  # can be displayed in error messages
+  e2name <- deparse(substitute(e2))
+  
+  if      (is.ggcyto_par(e1))  add_par(e1, e2, e2name)
+  else if (is.ggcyto_flowSet(e1)) add_ggcyto(e1, e2, e2name)
+  
 }
 
 #' @export
@@ -172,7 +197,7 @@ add_ggcyto <- function(e1, e2, e2name){
   fs <- e1[["data"]]
   dims <- attr(fs, "dims")
   chnl <- dims[, name]
-
+  
   is.recorded <- attr(e2, "is.recorded")
   if(is.null(is.recorded))
     is.recorded <- FALSE
@@ -188,7 +213,8 @@ add_ggcyto <- function(e1, e2, e2name){
   }else if(is.ggproto(e2)){
     layer_data <- e2$data  
     if(!is.null(layer_data)){
-      pd <- .pd2dt(pData(fs))
+      # Get pData from plot object
+      pd <- .pd2dt(pData(fs), pData = e1[["pData"]])
     }
     
     if(is(layer_data, "filterList")){
@@ -275,7 +301,7 @@ add_ggcyto <- function(e1, e2, e2name){
     e1[["GeomStats"]] <- NULL
     return(e1)
   }else if (is.ggcyto_par(e2)) {
-      
+    
     for(element in names(e2)){
       #skip hex_fill for 1d plot
       
@@ -284,35 +310,35 @@ add_ggcyto <- function(e1, e2, e2name){
       e2.new <- e2[[element]]
       #apply instrument range to limits
       if(element == "limits" ){
-            instrument_range <- e1[["instrument_range"]]
-            if(is.list(e2.new))
-            {
-              this_limits <- e2.new
-            }else if(is.character(e2.new))
-            {
-              this_limits <- list()
-              if(e2.new == "instrument")
-              {
-                for(aes_name in dims[, axis])
-                  this_limits[[aes_name]] <- instrument_range[, dims[axis == aes_name, name]]    
-              }else if(e2.new == "data")
-              {
-                # store the ggcyto pars for the lazy-eval elements for we may not have the final version of data yet at this stage
-                e1$ggcyto_pars <- add_par(e1$ggcyto_pars, e2, deparse(substitute(e2)))
-                next
-              }else
-                stop("invalid 'limits' setting!")
-            
-            }
-            #clear the lazy element (i.e. limits = "data") for non-lazy limits setting
-            #so that it won't be applied later on
-            e1$ggcyto_pars <- modifyList(e1$ggcyto_pars, list(limits = NULL))
-            e2.new <- coord_cartesian(xlim = this_limits[["x"]], ylim = this_limits[["y"]])
+        instrument_range <- e1[["instrument_range"]]
+        if(is.list(e2.new))
+        {
+          this_limits <- e2.new
+        }else if(is.character(e2.new))
+        {
+          this_limits <- list()
+          if(e2.new == "instrument")
+          {
+            for(aes_name in dims[, axis])
+              this_limits[[aes_name]] <- instrument_range[, dims[axis == aes_name, name]]    
+          }else if(e2.new == "data")
+          {
+            # store the ggcyto pars for the lazy-eval elements for we may not have the final version of data yet at this stage
+            e1$ggcyto_pars <- add_par(e1$ggcyto_pars, e2, deparse(substitute(e2)))
+            next
+          }else
+            stop("invalid 'limits' setting!")
+          
+        }
+        #clear the lazy element (i.e. limits = "data") for non-lazy limits setting
+        #so that it won't be applied later on
+        e1$ggcyto_pars <- modifyList(e1$ggcyto_pars, list(limits = NULL))
+        e2.new <- coord_cartesian(xlim = this_limits[["x"]], ylim = this_limits[["y"]])
       }
       attr(e2.new, "is.recorded") <- TRUE
       e1 <- e1 + e2.new
     }
-      
+    
     
     
     return(e1)
@@ -325,18 +351,18 @@ add_ggcyto <- function(e1, e2, e2name){
       marker <- thisDim[, desc]
       chnl <- thisDim[, name]
       lab_txt[[axis_name]] <- switch(e2[["labels"]]
-                                  , "marker" = ifelse(is.na(marker), chnl, marker)
-                                  , "channel" = chnl
-                                  , "both" = paste0(chnl, ifelse(is.na(marker), "", paste0(" ", marker)))
-                                  )
-                        
+                                     , "marker" = ifelse(is.na(marker), chnl, marker)
+                                     , "channel" = chnl
+                                     , "both" = paste0(chnl, ifelse(is.na(marker), "", paste0(" ", marker)))
+      )
+      
     }
     e2 <- labs(!!!lab_txt)
     
   }else if(is.theme(e2)){
     #have to take care of theme object since it inherits gg class and will
     #cause the dispatch conflicts due to the special rule of groupGeneric
-   ggplot_add(e2, e1)
+    ggplot_add(e2, e1)
   }else if(is(e2, "logicalGates")){
     
     if(is(fs, "GatingSet")){
@@ -425,8 +451,8 @@ is.geom_gate_filterList <- function(layer){
     verts <- sapply(markers, function(marker)unique(df[[marker]]), simplify = FALSE)
     if(all(sapply(verts, length) == 2))
     {
-     
-     rectangleGate(verts)
+      
+      rectangleGate(verts)
     }else
       polygonGate(df)  
     

--- a/man/autoplot.Rd
+++ b/man/autoplot.Rd
@@ -12,7 +12,7 @@
 \alias{autoplot.GatingHierarchy}
 \title{Plot cytometry data in one or two dimension with the ggcyto package.}
 \usage{
-\method{autoplot}{flowSet}(object, x, y = NULL, bins = 30, ...)
+\method{autoplot}{flowSet}(object, x, y = NULL, bins = 30, pData = NULL, ...)
 
 \method{autoplot}{ncdfFlowList}(object, ...)
 
@@ -31,6 +31,7 @@
   y = "SSC-A",
   bins = 30,
   axis_inverse_trans = TRUE,
+  pData = NULL,
   ...
 )
 
@@ -56,6 +57,8 @@
 \item{y}{define the y dimension of the plot. Default is NULL, which means 1d densityplot.}
 
 \item{bins}{passed to geom_hex}
+
+\item{pData}{Optional data.frame to use in place of the flowSet/GatingSet pData during plotting. Must have the same sample names (rownames) as the original pData. Columns can have different classes (e.g., factors with custom levels) to control plotting order. The original pData is not modified.}
 
 \item{...}{other arguments passed to ggplot}
 

--- a/man/compute_stats.Rd
+++ b/man/compute_stats.Rd
@@ -4,7 +4,14 @@
 \alias{compute_stats}
 \title{compute the statistics of the cell population defined by gates}
 \usage{
-compute_stats(fs = NULL, gates, type = "percent", value = NULL, ...)
+compute_stats(
+  fs = NULL,
+  gates,
+  type = "percent",
+  value = NULL,
+  pData = NULL,
+  ...
+)
 }
 \arguments{
 \item{fs}{flowSet. can be NULL when precaculated 'value' is provided}
@@ -14,6 +21,8 @@ compute_stats(fs = NULL, gates, type = "percent", value = NULL, ...)
 \item{type}{a vector of strings to specify the stats types. can be any or multiple values of "percent", "count", "gate_name", or "MFI" (MFI is currently not supported yet).}
 
 \item{value}{the pre-calculated stats value. when supplied, the stats computing is skipped.}
+
+\item{pData}{Optional custom pData to use instead of pData(fs) to control the plot order.}
 
 \item{...}{other arguments passed to stat_position function}
 }

--- a/man/fortify.filterList.Rd
+++ b/man/fortify.filterList.Rd
@@ -4,7 +4,7 @@
 \alias{fortify.filterList}
 \title{Convert a filterList to a data.table useful for ggplot}
 \usage{
-\method{fortify}{filterList}(model, data = NULL, nPoints = NULL, ...)
+\method{fortify}{filterList}(model, data = NULL, nPoints = NULL, pData = NULL, ...)
 }
 \arguments{
 \item{model}{filterList}
@@ -12,6 +12,8 @@
 \item{data}{not used}
 
 \item{nPoints}{not used}
+
+\item{pData}{Optional custom pData to use}
 
 \item{...}{not used.}
 }

--- a/man/fortify.flowSet.Rd
+++ b/man/fortify.flowSet.Rd
@@ -15,7 +15,7 @@
 
 \method{fortify}{flowFrame}(model, data, ...)
 
-\method{fortify}{flowSet}(model, data, ...)
+\method{fortify}{flowSet}(model, data, pData = NULL, ...)
 
 \method{fortify}{cytoset}(model, ...)
 
@@ -23,7 +23,7 @@
 
 \method{fortify}{GatingSetList}(model, ...)
 
-\method{fortify}{GatingSet}(model, ...)
+\method{fortify}{GatingSet}(model, pData = NULL, ...)
 }
 \arguments{
 \item{model}{flowFrame, flowSet or GatingSet}
@@ -31,10 +31,10 @@
 \item{...}{not used.}
 
 \item{data}{not used.}
+
+\item{pData}{Optional custom pData to use instead of pData(model)}
 }
 \value{
-data.table
-
 data.table
 
 data.table

--- a/man/ggcyto.Rd
+++ b/man/ggcyto.Rd
@@ -23,7 +23,14 @@ ggcyto(data = NULL, ...)
 
 \method{ggcyto}{GatingHierarchy}(data, ...)
 
-\method{ggcyto}{flowSet}(data, mapping, filter = NULL, max_nrow_to_plot = 50000, ...)
+\method{ggcyto}{flowSet}(
+  data,
+  mapping,
+  filter = NULL,
+  max_nrow_to_plot = 50000,
+  pData = NULL,
+  ...
+)
 }
 \arguments{
 \item{data}{The data source. A core cytometry data structure. (flowSet, flowFrame, ncdfFlowSet, GatingSet or GatingHierarchy)}
@@ -41,6 +48,8 @@ based on the geom_gate layer to be added later.}
 The gate is used to filter the flow data before it is plotted.}
 
 \item{max_nrow_to_plot}{the maximum number of cells to be plotted. When the actual data exceeds it, The subsampling process will be triggered to speed up plotting. Default is 5e4. To turn off the subsampling, simply set it to a large enough number or Inf.}
+
+\item{pData}{Optional data.frame to use in place of the flowSet/GatingSet pData during plotting. Must have the same sample names (rownames) as the original pData. Columns can have different classes (e.g., factors with custom levels) to control plotting order. The original pData is not modified.}
 }
 \value{
 ggcyto object

--- a/tests/testthat/_snaps/custom-pData/ggcyto-fs-custom-order.svg
+++ b/tests/testthat/_snaps/custom-pData/ggcyto-fs-custom-order.svg
@@ -1,0 +1,534 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDU2LjA4fDI4MS4yMQ=='>
+    <rect x='42.58' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDU2LjA4fDI4MS4yMQ==)'>
+<rect x='42.58' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.58,243.94 262.91,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,189.86 262.91,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,135.79 262.91,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,81.72 262.91,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='67.46,281.21 67.46,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='119.09,281.21 119.09,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='170.71,281.21 170.71,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='222.33,281.21 222.33,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,270.98 262.91,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,216.90 262.91,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,162.83 262.91,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,108.75 262.91,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='93.28,281.21 93.28,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='144.90,281.21 144.90,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='196.52,281.21 196.52,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='248.14,281.21 248.14,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='49.14' y='257.57' width='6.91' height='13.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='56.05' y='241.75' width='6.91' height='29.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='62.96' y='257.61' width='6.91' height='13.37' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='69.86' y='261.07' width='6.91' height='9.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='76.77' y='258.08' width='6.91' height='12.89' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='83.68' y='255.62' width='6.91' height='15.36' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='90.58' y='254.95' width='6.91' height='16.03' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='97.49' y='256.89' width='6.91' height='14.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='104.40' y='258.73' width='6.91' height='12.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='111.31' y='258.47' width='6.91' height='12.50' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='118.21' y='257.31' width='6.91' height='13.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='125.12' y='258.99' width='6.91' height='11.98' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='132.03' y='260.96' width='6.91' height='10.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='138.93' y='263.90' width='6.91' height='7.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='145.84' y='266.80' width='6.91' height='4.17' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='152.75' y='267.77' width='6.91' height='3.20' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='159.65' y='267.17' width='6.91' height='3.81' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='166.56' y='267.06' width='6.91' height='3.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='173.47' y='266.89' width='6.91' height='4.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='180.37' y='266.93' width='6.91' height='4.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='187.28' y='268.36' width='6.91' height='2.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='194.19' y='269.24' width='6.91' height='1.73' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='201.09' y='269.85' width='6.91' height='1.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='208.00' y='270.22' width='6.91' height='0.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='214.91' y='270.52' width='6.91' height='0.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='221.81' y='270.50' width='6.91' height='0.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='228.72' y='270.76' width='6.91' height='0.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='235.63' y='270.65' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='242.53' y='270.63' width='6.91' height='0.35' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='249.44' y='268.83' width='6.91' height='2.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDMxOS45OXw1NDUuMTE='>
+    <rect x='42.58' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDMxOS45OXw1NDUuMTE=)'>
+<rect x='42.58' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.58,507.84 262.91,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,453.77 262.91,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,399.69 262.91,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,345.62 262.91,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='67.46,545.11 67.46,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='119.09,545.11 119.09,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='170.71,545.11 170.71,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='222.33,545.11 222.33,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,534.88 262.91,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,480.81 262.91,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,426.73 262.91,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,372.66 262.91,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='93.28,545.11 93.28,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='144.90,545.11 144.90,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='196.52,545.11 196.52,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='248.14,545.11 248.14,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='49.14' y='497.87' width='6.91' height='37.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='56.05' y='400.32' width='6.91' height='134.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='62.96' y='498.61' width='6.91' height='36.27' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='69.86' y='518.64' width='6.91' height='16.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='76.77' y='519.65' width='6.91' height='15.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='83.68' y='504.21' width='6.91' height='30.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='90.58' y='473.30' width='6.91' height='61.58' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='97.49' y='476.05' width='6.91' height='58.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='104.40' y='510.76' width='6.91' height='24.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='111.31' y='531.29' width='6.91' height='3.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='118.21' y='533.97' width='6.91' height='0.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='125.12' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='132.03' y='534.56' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='138.93' y='534.56' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='145.84' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='152.75' y='534.68' width='6.91' height='0.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='159.65' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='166.56' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='173.47' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='180.37' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='187.28' y='534.77' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='194.19' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='201.09' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='208.00' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='214.91' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='221.81' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='228.72' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='235.63' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='242.53' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='249.44' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXw1Ni4wOHwyODEuMjE='>
+    <rect x='268.39' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXw1Ni4wOHwyODEuMjE=)'>
+<rect x='268.39' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='268.39,243.94 488.71,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,189.86 488.71,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,135.79 488.71,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,81.72 488.71,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='293.27,281.21 293.27,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='344.89,281.21 344.89,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='396.52,281.21 396.52,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='448.14,281.21 448.14,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,270.98 488.71,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,216.90 488.71,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,162.83 488.71,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,108.75 488.71,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='319.08,281.21 319.08,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='370.70,281.21 370.70,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='422.33,281.21 422.33,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='473.95,281.21 473.95,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='274.95' y='267.88' width='6.91' height='3.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='281.86' y='264.72' width='6.91' height='6.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='288.76' y='267.30' width='6.91' height='3.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='295.67' y='268.06' width='6.91' height='2.92' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='302.58' y='267.21' width='6.91' height='3.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='309.48' y='265.78' width='6.91' height='5.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='316.39' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='323.30' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='330.20' y='264.12' width='6.91' height='6.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='337.11' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='344.02' y='265.50' width='6.91' height='5.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='350.92' y='265.57' width='6.91' height='5.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='357.83' y='265.98' width='6.91' height='5.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='364.74' y='267.95' width='6.91' height='3.03' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='371.64' y='269.22' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='378.55' y='269.59' width='6.91' height='1.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='385.46' y='269.22' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='392.37' y='269.74' width='6.91' height='1.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='399.27' y='269.89' width='6.91' height='1.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='406.18' y='270.24' width='6.91' height='0.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='413.09' y='270.41' width='6.91' height='0.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='419.99' y='270.56' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='426.90' y='270.67' width='6.91' height='0.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='433.81' y='270.52' width='6.91' height='0.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='440.71' y='270.93' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='447.62' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='454.53' y='270.87' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='461.43' y='270.78' width='6.91' height='0.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='468.34' y='270.72' width='6.91' height='0.26' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='475.25' y='269.29' width='6.91' height='1.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzMTkuOTl8NTQ1LjEx'>
+    <rect x='268.39' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzMTkuOTl8NTQ1LjEx)'>
+<rect x='268.39' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='268.39,507.84 488.71,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,453.77 488.71,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,399.69 488.71,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,345.62 488.71,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='293.27,545.11 293.27,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='344.89,545.11 344.89,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='396.52,545.11 396.52,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='448.14,545.11 448.14,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,534.88 488.71,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,480.81 488.71,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,426.73 488.71,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,372.66 488.71,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='319.08,545.11 319.08,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='370.70,545.11 370.70,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='422.33,545.11 422.33,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='473.95,545.11 473.95,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='274.95' y='450.35' width='6.91' height='84.53' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='281.86' y='330.22' width='6.91' height='204.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='288.76' y='343.80' width='6.91' height='191.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='295.67' y='406.36' width='6.91' height='128.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='302.58' y='461.06' width='6.91' height='73.82' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='309.48' y='480.26' width='6.91' height='54.61' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='316.39' y='492.53' width='6.91' height='42.35' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='323.30' y='502.67' width='6.91' height='32.21' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='330.20' y='517.79' width='6.91' height='17.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='337.11' y='527.66' width='6.91' height='7.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='344.02' y='532.82' width='6.91' height='2.05' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='350.92' y='533.58' width='6.91' height='1.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='357.83' y='533.88' width='6.91' height='0.99' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='364.74' y='534.27' width='6.91' height='0.61' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='371.64' y='534.25' width='6.91' height='0.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='378.55' y='534.25' width='6.91' height='0.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='385.46' y='534.36' width='6.91' height='0.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='392.37' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='399.27' y='534.38' width='6.91' height='0.50' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='406.18' y='534.58' width='6.91' height='0.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='413.09' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='419.99' y='534.60' width='6.91' height='0.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='426.90' y='534.62' width='6.91' height='0.26' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='433.81' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='440.71' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='447.62' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='454.53' y='534.77' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='461.43' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='468.34' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='475.25' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41Mnw1Ni4wOHwyODEuMjE='>
+    <rect x='494.19' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41Mnw1Ni4wOHwyODEuMjE=)'>
+<rect x='494.19' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='494.19,243.94 714.52,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,189.86 714.52,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,135.79 714.52,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,81.72 714.52,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='519.08,281.21 519.08,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='570.70,281.21 570.70,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='622.32,281.21 622.32,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='673.94,281.21 673.94,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,270.98 714.52,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,216.90 714.52,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,162.83 714.52,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,108.75 714.52,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='544.89,281.21 544.89,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='596.51,281.21 596.51,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='648.13,281.21 648.13,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='699.76,281.21 699.76,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='500.76' y='264.55' width='6.91' height='6.42' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='507.66' y='237.21' width='6.91' height='33.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='514.57' y='240.09' width='6.91' height='30.89' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='521.48' y='249.28' width='6.91' height='21.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='528.38' y='253.74' width='6.91' height='17.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='535.29' y='248.63' width='6.91' height='22.34' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='542.20' y='220.75' width='6.91' height='50.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='549.10' y='201.07' width='6.91' height='69.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='556.01' y='237.77' width='6.91' height='33.20' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='562.92' y='262.45' width='6.91' height='8.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='569.82' y='268.53' width='6.91' height='2.44' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='576.73' y='270.02' width='6.91' height='0.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='583.64' y='269.94' width='6.91' height='1.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='590.54' y='270.24' width='6.91' height='0.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='597.45' y='270.46' width='6.91' height='0.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='604.36' y='270.65' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='611.26' y='270.41' width='6.91' height='0.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='618.17' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='625.08' y='270.89' width='6.91' height='0.087' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='631.98' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='638.89' y='270.91' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='645.80' y='270.89' width='6.91' height='0.087' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='652.70' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='659.61' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='666.52' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='673.43' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='680.33' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='687.24' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='694.15' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='701.05' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzMTkuOTl8NTQ1LjEx'>
+    <rect x='494.19' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzMTkuOTl8NTQ1LjEx)'>
+<rect x='494.19' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='494.19,507.84 714.52,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,453.77 714.52,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,399.69 714.52,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,345.62 714.52,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='519.08,545.11 519.08,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='570.70,545.11 570.70,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='622.32,545.11 622.32,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='673.94,545.11 673.94,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,534.88 714.52,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,480.81 714.52,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,426.73 714.52,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,372.66 714.52,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='544.89,545.11 544.89,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='596.51,545.11 596.51,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='648.13,545.11 648.13,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='699.76,545.11 699.76,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='500.76' y='530.40' width='6.91' height='4.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='507.66' y='523.29' width='6.91' height='11.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='514.57' y='525.92' width='6.91' height='8.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='521.48' y='524.97' width='6.91' height='9.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='528.38' y='521.58' width='6.91' height='13.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='535.29' y='506.24' width='6.91' height='28.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='542.20' y='482.86' width='6.91' height='52.02' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='549.10' y='469.39' width='6.91' height='65.49' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='556.01' y='494.50' width='6.91' height='40.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='562.92' y='521.02' width='6.91' height='13.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='569.82' y='528.72' width='6.91' height='6.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='576.73' y='533.13' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='583.64' y='534.10' width='6.91' height='0.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='590.54' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='597.45' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='604.36' y='534.71' width='6.91' height='0.17' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='611.26' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='618.17' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='625.08' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='631.98' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='638.89' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='645.80' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='652.70' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='659.61' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='666.52' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='673.43' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='680.33' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='687.24' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='694.15' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='701.05' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDI4Ni42OXwzMDMuMzQ='>
+    <rect x='42.58' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDI4Ni42OXwzMDMuMzQ=)'>
+<rect x='42.58' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDMwMy4zNHwzMTkuOTk='>
+    <rect x='42.58' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDMwMy4zNHwzMTkuOTk=)'>
+<rect x='42.58' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwyODYuNjl8MzAzLjM0'>
+    <rect x='268.39' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwyODYuNjl8MzAzLjM0)'>
+<rect x='268.39' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzMDMuMzR8MzE5Ljk5'>
+    <rect x='268.39' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzMDMuMzR8MzE5Ljk5)'>
+<rect x='268.39' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwyODYuNjl8MzAzLjM0'>
+    <rect x='494.19' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwyODYuNjl8MzAzLjM0)'>
+<rect x='494.19' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzMDMuMzR8MzE5Ljk5'>
+    <rect x='494.19' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzMDMuMzR8MzE5Ljk5)'>
+<rect x='494.19' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDIyLjc4fDM5LjQz'>
+    <rect x='42.58' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDIyLjc4fDM5LjQz)'>
+<rect x='42.58' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDM5LjQzfDU2LjA4'>
+    <rect x='42.58' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDM5LjQzfDU2LjA4)'>
+<rect x='42.58' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwyMi43OHwzOS40Mw=='>
+    <rect x='268.39' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwyMi43OHwzOS40Mw==)'>
+<rect x='268.39' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzOS40M3w1Ni4wOA=='>
+    <rect x='268.39' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzOS40M3w1Ni4wOA==)'>
+<rect x='268.39' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='494.19' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='494.19' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzOS40M3w1Ni4wOA=='>
+    <rect x='494.19' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzOS40M3w1Ni4wOA==)'>
+<rect x='494.19' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='93.28,547.85 93.28,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.90,547.85 144.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='196.52,547.85 196.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='248.14,547.85 248.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='93.28' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='144.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='196.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='248.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<polyline points='319.08,547.85 319.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='370.70,547.85 370.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='422.33,547.85 422.33,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='473.95,547.85 473.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='319.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='370.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='422.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='473.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<polyline points='544.89,547.85 544.89,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='596.51,547.85 596.51,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='648.13,547.85 648.13,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='699.76,547.85 699.76,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='544.89' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='596.51' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='648.13' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='699.76' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='37.65' y='274.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='37.65' y='219.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<text x='37.65' y='165.86' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='37.65' y='111.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>7500</text>
+<polyline points='39.84,270.98 42.58,270.98 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,216.90 42.58,216.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,162.83 42.58,162.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,108.75 42.58,108.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='37.65' y='537.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='37.65' y='483.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<text x='37.65' y='429.76' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='37.65' y='375.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>7500</text>
+<polyline points='39.84,534.88 42.58,534.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,480.81 42.58,480.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,426.73 42.58,426.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,372.66 42.58,372.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='378.55' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='94.14px' lengthAdjust='spacingAndGlyphs'>FSC-H FSC-Height</text>
+<text transform='translate(13.05,300.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='42.58' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='135.74px' lengthAdjust='spacingAndGlyphs'>ggcyto-fs-custom-order</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/custom-pData/ggcyto-fs-default-order.svg
+++ b/tests/testthat/_snaps/custom-pData/ggcyto-fs-default-order.svg
@@ -1,0 +1,534 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDU2LjA4fDI4MS4yMQ=='>
+    <rect x='42.58' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDU2LjA4fDI4MS4yMQ==)'>
+<rect x='42.58' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.58,243.94 262.91,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,189.86 262.91,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,135.79 262.91,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,81.72 262.91,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='67.46,281.21 67.46,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='119.09,281.21 119.09,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='170.71,281.21 170.71,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='222.33,281.21 222.33,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,270.98 262.91,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,216.90 262.91,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,162.83 262.91,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,108.75 262.91,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='93.28,281.21 93.28,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='144.90,281.21 144.90,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='196.52,281.21 196.52,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='248.14,281.21 248.14,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='49.14' y='257.57' width='6.91' height='13.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='56.05' y='241.75' width='6.91' height='29.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='62.96' y='257.61' width='6.91' height='13.37' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='69.86' y='261.07' width='6.91' height='9.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='76.77' y='258.08' width='6.91' height='12.89' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='83.68' y='255.62' width='6.91' height='15.36' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='90.58' y='254.95' width='6.91' height='16.03' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='97.49' y='256.89' width='6.91' height='14.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='104.40' y='258.73' width='6.91' height='12.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='111.31' y='258.47' width='6.91' height='12.50' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='118.21' y='257.31' width='6.91' height='13.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='125.12' y='258.99' width='6.91' height='11.98' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='132.03' y='260.96' width='6.91' height='10.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='138.93' y='263.90' width='6.91' height='7.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='145.84' y='266.80' width='6.91' height='4.17' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='152.75' y='267.77' width='6.91' height='3.20' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='159.65' y='267.17' width='6.91' height='3.81' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='166.56' y='267.06' width='6.91' height='3.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='173.47' y='266.89' width='6.91' height='4.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='180.37' y='266.93' width='6.91' height='4.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='187.28' y='268.36' width='6.91' height='2.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='194.19' y='269.24' width='6.91' height='1.73' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='201.09' y='269.85' width='6.91' height='1.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='208.00' y='270.22' width='6.91' height='0.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='214.91' y='270.52' width='6.91' height='0.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='221.81' y='270.50' width='6.91' height='0.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='228.72' y='270.76' width='6.91' height='0.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='235.63' y='270.65' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='242.53' y='270.63' width='6.91' height='0.35' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='249.44' y='268.83' width='6.91' height='2.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDMxOS45OXw1NDUuMTE='>
+    <rect x='42.58' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDMxOS45OXw1NDUuMTE=)'>
+<rect x='42.58' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='42.58,507.84 262.91,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,453.77 262.91,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,399.69 262.91,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,345.62 262.91,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='67.46,545.11 67.46,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='119.09,545.11 119.09,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='170.71,545.11 170.71,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='222.33,545.11 222.33,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,534.88 262.91,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,480.81 262.91,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,426.73 262.91,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='42.58,372.66 262.91,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='93.28,545.11 93.28,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='144.90,545.11 144.90,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='196.52,545.11 196.52,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='248.14,545.11 248.14,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='49.14' y='497.87' width='6.91' height='37.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='56.05' y='400.32' width='6.91' height='134.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='62.96' y='498.61' width='6.91' height='36.27' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='69.86' y='518.64' width='6.91' height='16.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='76.77' y='519.65' width='6.91' height='15.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='83.68' y='504.21' width='6.91' height='30.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='90.58' y='473.30' width='6.91' height='61.58' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='97.49' y='476.05' width='6.91' height='58.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='104.40' y='510.76' width='6.91' height='24.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='111.31' y='531.29' width='6.91' height='3.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='118.21' y='533.97' width='6.91' height='0.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='125.12' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='132.03' y='534.56' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='138.93' y='534.56' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='145.84' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='152.75' y='534.68' width='6.91' height='0.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='159.65' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='166.56' y='534.75' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='173.47' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='180.37' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='187.28' y='534.77' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='194.19' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='201.09' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='208.00' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='214.91' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='221.81' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='228.72' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='235.63' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='242.53' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='249.44' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXw1Ni4wOHwyODEuMjE='>
+    <rect x='268.39' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXw1Ni4wOHwyODEuMjE=)'>
+<rect x='268.39' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='268.39,243.94 488.71,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,189.86 488.71,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,135.79 488.71,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,81.72 488.71,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='293.27,281.21 293.27,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='344.89,281.21 344.89,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='396.52,281.21 396.52,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='448.14,281.21 448.14,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,270.98 488.71,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,216.90 488.71,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,162.83 488.71,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,108.75 488.71,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='319.08,281.21 319.08,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='370.70,281.21 370.70,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='422.33,281.21 422.33,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='473.95,281.21 473.95,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='274.95' y='267.88' width='6.91' height='3.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='281.86' y='264.72' width='6.91' height='6.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='288.76' y='267.30' width='6.91' height='3.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='295.67' y='268.06' width='6.91' height='2.92' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='302.58' y='267.21' width='6.91' height='3.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='309.48' y='265.78' width='6.91' height='5.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='316.39' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='323.30' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='330.20' y='264.12' width='6.91' height='6.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='337.11' y='264.85' width='6.91' height='6.12' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='344.02' y='265.50' width='6.91' height='5.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='350.92' y='265.57' width='6.91' height='5.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='357.83' y='265.98' width='6.91' height='5.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='364.74' y='267.95' width='6.91' height='3.03' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='371.64' y='269.22' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='378.55' y='269.59' width='6.91' height='1.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='385.46' y='269.22' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='392.37' y='269.74' width='6.91' height='1.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='399.27' y='269.89' width='6.91' height='1.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='406.18' y='270.24' width='6.91' height='0.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='413.09' y='270.41' width='6.91' height='0.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='419.99' y='270.56' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='426.90' y='270.67' width='6.91' height='0.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='433.81' y='270.52' width='6.91' height='0.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='440.71' y='270.93' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='447.62' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='454.53' y='270.87' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='461.43' y='270.78' width='6.91' height='0.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='468.34' y='270.72' width='6.91' height='0.26' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='475.25' y='269.29' width='6.91' height='1.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzMTkuOTl8NTQ1LjEx'>
+    <rect x='268.39' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzMTkuOTl8NTQ1LjEx)'>
+<rect x='268.39' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='268.39,507.84 488.71,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,453.77 488.71,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,399.69 488.71,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,345.62 488.71,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='293.27,545.11 293.27,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='344.89,545.11 344.89,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='396.52,545.11 396.52,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='448.14,545.11 448.14,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,534.88 488.71,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,480.81 488.71,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,426.73 488.71,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='268.39,372.66 488.71,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='319.08,545.11 319.08,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='370.70,545.11 370.70,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='422.33,545.11 422.33,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='473.95,545.11 473.95,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='274.95' y='450.35' width='6.91' height='84.53' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='281.86' y='330.22' width='6.91' height='204.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='288.76' y='343.80' width='6.91' height='191.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='295.67' y='406.36' width='6.91' height='128.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='302.58' y='461.06' width='6.91' height='73.82' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='309.48' y='480.26' width='6.91' height='54.61' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='316.39' y='492.53' width='6.91' height='42.35' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='323.30' y='502.67' width='6.91' height='32.21' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='330.20' y='517.79' width='6.91' height='17.09' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='337.11' y='527.66' width='6.91' height='7.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='344.02' y='532.82' width='6.91' height='2.05' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='350.92' y='533.58' width='6.91' height='1.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='357.83' y='533.88' width='6.91' height='0.99' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='364.74' y='534.27' width='6.91' height='0.61' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='371.64' y='534.25' width='6.91' height='0.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='378.55' y='534.25' width='6.91' height='0.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='385.46' y='534.36' width='6.91' height='0.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='392.37' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='399.27' y='534.38' width='6.91' height='0.50' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='406.18' y='534.58' width='6.91' height='0.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='413.09' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='419.99' y='534.60' width='6.91' height='0.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='426.90' y='534.62' width='6.91' height='0.26' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='433.81' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='440.71' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='447.62' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='454.53' y='534.77' width='6.91' height='0.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='461.43' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='468.34' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='475.25' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41Mnw1Ni4wOHwyODEuMjE='>
+    <rect x='494.19' y='56.08' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41Mnw1Ni4wOHwyODEuMjE=)'>
+<rect x='494.19' y='56.08' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='494.19,243.94 714.52,243.94 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,189.86 714.52,189.86 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,135.79 714.52,135.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,81.72 714.52,81.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='519.08,281.21 519.08,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='570.70,281.21 570.70,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='622.32,281.21 622.32,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='673.94,281.21 673.94,56.08 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,270.98 714.52,270.98 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,216.90 714.52,216.90 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,162.83 714.52,162.83 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,108.75 714.52,108.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='544.89,281.21 544.89,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='596.51,281.21 596.51,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='648.13,281.21 648.13,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='699.76,281.21 699.76,56.08 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='500.76' y='264.55' width='6.91' height='6.42' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='507.66' y='237.21' width='6.91' height='33.76' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='514.57' y='240.09' width='6.91' height='30.89' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='521.48' y='249.28' width='6.91' height='21.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='528.38' y='253.74' width='6.91' height='17.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='535.29' y='248.63' width='6.91' height='22.34' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='542.20' y='220.75' width='6.91' height='50.22' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='549.10' y='201.07' width='6.91' height='69.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='556.01' y='237.77' width='6.91' height='33.20' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='562.92' y='262.45' width='6.91' height='8.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='569.82' y='268.53' width='6.91' height='2.44' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='576.73' y='270.02' width='6.91' height='0.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='583.64' y='269.94' width='6.91' height='1.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='590.54' y='270.24' width='6.91' height='0.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='597.45' y='270.46' width='6.91' height='0.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='604.36' y='270.65' width='6.91' height='0.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='611.26' y='270.41' width='6.91' height='0.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='618.17' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='625.08' y='270.89' width='6.91' height='0.087' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='631.98' y='270.85' width='6.91' height='0.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='638.89' y='270.91' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='645.80' y='270.89' width='6.91' height='0.087' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='652.70' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='659.61' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='666.52' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='673.43' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='680.33' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='687.24' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='694.15' y='270.98' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='701.05' y='270.95' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzMTkuOTl8NTQ1LjEx'>
+    <rect x='494.19' y='319.99' width='220.33' height='225.12' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzMTkuOTl8NTQ1LjEx)'>
+<rect x='494.19' y='319.99' width='220.33' height='225.12' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='494.19,507.84 714.52,507.84 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,453.77 714.52,453.77 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,399.69 714.52,399.69 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,345.62 714.52,345.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='519.08,545.11 519.08,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='570.70,545.11 570.70,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='622.32,545.11 622.32,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='673.94,545.11 673.94,319.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,534.88 714.52,534.88 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,480.81 714.52,480.81 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,426.73 714.52,426.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.19,372.66 714.52,372.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='544.89,545.11 544.89,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='596.51,545.11 596.51,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='648.13,545.11 648.13,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='699.76,545.11 699.76,319.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='500.76' y='530.40' width='6.91' height='4.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='507.66' y='523.29' width='6.91' height='11.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='514.57' y='525.92' width='6.91' height='8.95' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='521.48' y='524.97' width='6.91' height='9.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='528.38' y='521.58' width='6.91' height='13.30' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='535.29' y='506.24' width='6.91' height='28.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='542.20' y='482.86' width='6.91' height='52.02' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='549.10' y='469.39' width='6.91' height='65.49' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='556.01' y='494.50' width='6.91' height='40.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='562.92' y='521.02' width='6.91' height='13.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='569.82' y='528.72' width='6.91' height='6.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='576.73' y='533.13' width='6.91' height='1.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='583.64' y='534.10' width='6.91' height='0.78' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='590.54' y='534.47' width='6.91' height='0.41' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='597.45' y='534.73' width='6.91' height='0.15' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='604.36' y='534.71' width='6.91' height='0.17' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='611.26' y='534.81' width='6.91' height='0.065' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='618.17' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='625.08' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='631.98' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='638.89' y='534.86' width='6.91' height='0.022' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='645.80' y='534.84' width='6.91' height='0.043' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='652.70' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='659.61' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='666.52' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='673.43' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='680.33' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='687.24' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='694.15' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='701.05' y='534.88' width='6.91' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDI4Ni42OXwzMDMuMzQ='>
+    <rect x='42.58' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDI4Ni42OXwzMDMuMzQ=)'>
+<rect x='42.58' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDMwMy4zNHwzMTkuOTk='>
+    <rect x='42.58' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDMwMy4zNHwzMTkuOTk=)'>
+<rect x='42.58' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwyODYuNjl8MzAzLjM0'>
+    <rect x='268.39' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwyODYuNjl8MzAzLjM0)'>
+<rect x='268.39' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzMDMuMzR8MzE5Ljk5'>
+    <rect x='268.39' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzMDMuMzR8MzE5Ljk5)'>
+<rect x='268.39' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwyODYuNjl8MzAzLjM0'>
+    <rect x='494.19' y='286.69' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwyODYuNjl8MzAzLjM0)'>
+<rect x='494.19' y='286.69' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzMDMuMzR8MzE5Ljk5'>
+    <rect x='494.19' y='303.34' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzMDMuMzR8MzE5Ljk5)'>
+<rect x='494.19' y='303.34' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='314.69' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDIyLjc4fDM5LjQz'>
+    <rect x='42.58' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDIyLjc4fDM5LjQz)'>
+<rect x='42.58' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDIuNTh8MjYyLjkxfDM5LjQzfDU2LjA4'>
+    <rect x='42.58' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDIuNTh8MjYyLjkxfDM5LjQzfDU2LjA4)'>
+<rect x='42.58' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='152.75' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwyMi43OHwzOS40Mw=='>
+    <rect x='268.39' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwyMi43OHwzOS40Mw==)'>
+<rect x='268.39' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY4LjM5fDQ4OC43MXwzOS40M3w1Ni4wOA=='>
+    <rect x='268.39' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY4LjM5fDQ4OC43MXwzOS40M3w1Ni4wOA==)'>
+<rect x='268.39' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='378.55' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwyMi43OHwzOS40Mw=='>
+    <rect x='494.19' y='22.78' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwyMi43OHwzOS40Mw==)'>
+<rect x='494.19' y='22.78' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDk0LjE5fDcxNC41MnwzOS40M3w1Ni4wOA=='>
+    <rect x='494.19' y='39.43' width='220.33' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk0LjE5fDcxNC41MnwzOS40M3w1Ni4wOA==)'>
+<rect x='494.19' y='39.43' width='220.33' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<text x='604.36' y='50.79' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='93.28,547.85 93.28,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='144.90,547.85 144.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='196.52,547.85 196.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='248.14,547.85 248.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='93.28' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='144.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='196.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='248.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<polyline points='319.08,547.85 319.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='370.70,547.85 370.70,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='422.33,547.85 422.33,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='473.95,547.85 473.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='319.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='370.70' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='422.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='473.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<polyline points='544.89,547.85 544.89,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='596.51,547.85 596.51,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='648.13,547.85 648.13,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='699.76,547.85 699.76,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='544.89' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<text x='596.51' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='648.13' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>750</text>
+<text x='699.76' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='37.65' y='274.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='37.65' y='219.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<text x='37.65' y='165.86' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='37.65' y='111.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>7500</text>
+<polyline points='39.84,270.98 42.58,270.98 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,216.90 42.58,216.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,162.83 42.58,162.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,108.75 42.58,108.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='37.65' y='537.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='37.65' y='483.83' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2500</text>
+<text x='37.65' y='429.76' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>5000</text>
+<text x='37.65' y='375.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>7500</text>
+<polyline points='39.84,534.88 42.58,534.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,480.81 42.58,480.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,426.73 42.58,426.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='39.84,372.66 42.58,372.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='378.55' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='94.14px' lengthAdjust='spacingAndGlyphs'>FSC-H FSC-Height</text>
+<text transform='translate(13.05,300.60) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='42.58' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='132.81px' lengthAdjust='spacingAndGlyphs'>ggcyto-fs-default-order</text>
+</g>
+</svg>

--- a/tests/testthat/test-custom-pData.R
+++ b/tests/testthat/test-custom-pData.R
@@ -1,0 +1,83 @@
+context("fortify")
+test_that("fortify -- ggcyto-fs-custom-order", {
+  # Create a subset of the data
+  fs <- GvHD[subset(pData(GvHD), Patient %in% 5:7 & Visit %in% c(5:6))[["name"]]]
+  
+  # Create custom pData with Patient as factor in custom order
+  custom_pd <- pData(fs)
+  custom_pd$Patient <- factor(custom_pd$Patient, levels = c("7", "6", "5"))
+  custom_pd$Visit <- factor(custom_pd$Visit, levels = c("6", "5"))
+  
+  # Original plot order
+  p1 <- ggcyto(fs, aes(x = `FSC-H`)) +
+    geom_histogram(bins = 30) +
+    facet_wrap(~Patient + Visit)
+  
+  # Manual plot order
+  p2 <- ggcyto(fs, aes(x = `FSC-H`), pData = custom_pd) +
+    geom_histogram(bins = 30) +
+    facet_wrap(~Patient + Visit)
+  
+  suppressWarnings(
+    expect_doppelganger(
+      "ggcyto-fs-default-order", 
+      p1
+    )
+  )
+  suppressWarnings(
+    expect_doppelganger(
+      "ggcyto-fs-custom-order", 
+      p1
+    )
+  )
+
+})
+
+test_that("fortify-- pData-rownames", {
+  fs <- GvHD[1:3]
+  
+  # Create pData with wrong rownames
+  wrong_pd <- data.frame(
+    name = c("a", "b", "c"),
+    Patient = c("1", "2", "3"),
+    row.names = c("wrong1", "wrong2", "wrong3")
+  )
+  
+  # Should error because rownames don't match
+  expect_error(
+    ggcyto(fs, aes(x = `FSC-H`), pData = wrong_pd),
+    "rownames must match"
+  )
+})
+
+test_that("fortify-- pData-columns", {
+  fs <- GvHD[1:3]
+  
+  # Create pData with only some columns
+  partial_pd <- data.frame(
+    name = sampleNames(fs),
+    row.names = sampleNames(fs)
+  )
+  
+  # Should warn about missing columns
+  expect_warning(
+    ggcyto(fs, aes(x = `FSC-H`), pData = partial_pd),
+    "missing in supplied pData"
+  )
+})
+
+test_that("fortify-- pData-sample-order", {
+  fs <- GvHD[1:3]
+  
+  # Create pData with samples in different order
+  custom_pd <- pData(fs)
+  # Reverse the order of rows
+  custom_pd <- custom_pd[rev(rownames(custom_pd)), , drop = FALSE]
+  custom_pd$Test <- factor(rownames(custom_pd), levels = rownames(custom_pd))
+  
+  # Should reorder to match flowSet
+  p <- ggcyto(fs, aes(x = `FSC-H`), pData = custom_pd)
+  
+  # The pData in the flowSet should match the original order
+  expect_equal(rownames(pData(p$data)), sampleNames(fs))
+})


### PR DESCRIPTION
@mikejiang here is my attempt at adding support for custom plot ordering in `ggcyto` to address the ordering issues raised here:

flowWorkspace: [Setting pData factor levels · Issue #297 · RGLab/flowWorkspace](https://github.com/RGLab/flowWorkspace/issues/297) 

ggcyto: [Facet ordering in ggcyto · Issue #76 · RGLab/ggcyto](https://github.com/RGLab/ggcyto/issues/76)

The proposed approach adds a new `pData` argument to flowSet and GatingSet methods of `ggcyto` and `autoplot` to allow users to manually supply metadata with appropriate formatting and ordering (i.e. factor levels). We make sure that `pData` has exactly the same row and column names as the input cytoset or GatingSet.

We simply inherit `pData` when fortifying using a data.table join on the rownames. The underlying pData in the cytoset or GatingSet remains unchanged. 

I've added a couple of tests to the test suite and confirmed that all other tests are passing locally. 

Here is a quick demo where I indicate a specific `Treatement` order and reverse the `OVAConc` order. 

```{r}
library(CytoExploreR)
library(CytoExploreRData)
library(ggcyto)

gs <- GatingSet(Activation)
gs <- cyto_compensate(gs)
gs <- cyto_transform(gs)
gs <- cyto_gatingTemplate_apply(gs, Activation_gatingTemplate)
pd <- pData(gs)

# all columns are characters
apply(pd, 2, class)
  Treatment     OVAConc        name 
"character" "character" "character" 

# default ggcyto ordering
ggcyto(
  gs, 
  aes(CD8, CD4),
  subset = "T Cells"
) +
geom_gate(c("CD4 T Cells", "CD8 T Cells")) +
geom_hex(bins = 256) +
geom_stats() +
facet_wrap(~Treatment+OVAConc, ncol = 4)
```
<img width="841" height="988" alt="image" src="https://github.com/user-attachments/assets/cba74855-1bd0-4243-a155-608ae65f8ea4" />

Using this method users can automatically reorder by multiple variables without having to manually specify the order for every plot - simply pass the the ordered metadata to each ggcyto or autoplot call for consistent ordering.

```{r}
# set factor levels manually
pd$Treatment <- factor(
  pd$Treatment, 
  levels = c("Stim-A", "Stim-D", "Stim-C", "Stim-B", "NA")
)
pd$OVAConc <- factor(
  pd$OVAConc,
  levels = c(500, 50, 5, 0)
)

# plot using custom ordering
ggcyto(
  gs, 
  aes(CD8, CD4),
  pData = pd,
  subset = "T Cells"
) +
geom_gate(c("CD4 T Cells", "CD8 T Cells")) +
geom_hex(bins = 256) +
geom_stats() +
facet_wrap(~Treatment+OVAConc, ncol = 4)
```
<img width="841" height="988" alt="image" src="https://github.com/user-attachments/assets/6211d1e2-56a4-49f5-89f4-2a933dfdd30c" />
